### PR TITLE
Fix nodeUsedMemory metric value

### DIFF
--- a/exporter.go
+++ b/exporter.go
@@ -341,7 +341,7 @@ func (e *Exporter) collectNodes(nodes nodeMap, ch chan<- prometheus.Metric) erro
 				logrus.Debugf("Fetched node %s stats", n.Name)
 
 				ch <- prometheus.MustNewConstMetric(
-					nodeUsedMemory, prometheus.GaugeValue, float64(nodeStats.Memory.Used)*1024*1024,
+					nodeUsedMemory, prometheus.GaugeValue, float64(nodeStats.Memory.Used),
 					nodeLabels...,
 				)
 				ch <- prometheus.MustNewConstMetric(


### PR DESCRIPTION
The `nodeStats.Memory.Used` value, provided by nomad API is already in bytes.
So it's not needed to multiply it by `1024*1024` to have a good value.

With this change the `nodeUsedMemory` uses the same unit than
`nodeAllocatedMemory` and `nodeResourceMemory` and can be compared to.

Tested against a nomad 0.8.7.
Not easy to find the real type in nomad source code. The memory value is computed using https://github.com/shirou/gopsutil/blob/master/mem